### PR TITLE
Fixed minor decompression bug.

### DIFF
--- a/src/lzip.lisp
+++ b/src/lzip.lisp
@@ -269,13 +269,13 @@ returned."
 
       (let* ((size (- +buffer-size+ output-index))
              (n (lz-decompress-read decoder ffi-buffer size)))
-        (unless (minusp n)
+        (unless (or (minusp n) (and (zerop n) first-member))
           (setf first-member
                 (when first-member
                   (zerop (lz-decompress-member-finished decoder))))
           (replace output buffer :start1 output-index :end2 n)
           (incf output-index n))
-        (when (or (minusp n) (and (zerop n) first-member))
+        (when (minusp n)
           (process-decompression-error stream))))
     output-index))
 


### PR DESCRIPTION
I have a .tar.lz containing a ~45mb json file, it was created with tar 1.34 & lzip 1.23
it compresses/decompresses fine with these tools, but throws an error decompressing with cl-lzlib.

The error was alway when n = 0, this patch fixes it for me, all files decompress correctly in my tests.